### PR TITLE
fix: break message loop on exit notification

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -196,6 +196,9 @@ where
             }
         };
 
+        // `message_fut` will resolve on an exit notification or if stdin
+        // closes. Don't abort it in any case, hence `future::pending()` in the
+        // other branch. But abort the other futures once it completes.
         tokio::select! {
             (..) = async { join!(future, print_output, process_server_responses, futures::future::pending::<()>()) } => unreachable!(),
             () = message_fut => {},

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -163,6 +163,8 @@ where
                             return;
                         }
 
+                        let is_exit = req.method() == "exit";
+
                         let fut = service
                             .call(RequestWithCancellation {
                                 request: req,
@@ -174,6 +176,10 @@ where
                             });
 
                         server_tasks_tx.send(fut).await.unwrap();
+
+                        if is_exit {
+                            break;
+                        }
                     }
                     Ok(Message::Response(res)) => {
                         if let Err(err) = client_responses.send(res).await {
@@ -190,7 +196,10 @@ where
             }
         };
 
-        join!(future, print_output, process_server_responses, message_fut);
+        tokio::select! {
+            (..) = async { join!(future, print_output, process_server_responses, futures::future::pending::<()>()) } => unreachable!(),
+            () = message_fut => {},
+        };
 
         client_abort.abort();
     }


### PR DESCRIPTION
Towards https://github.com/denoland/deno/issues/20700.

Previously the server loop only broke when stdin closed. VSCode doesn't close stdin before waiting for a shutdown language server process to exit. This makes it exit on receiving an exit notification.